### PR TITLE
Schedule Plugin

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -138,3 +138,8 @@ div.splitcontentleft ol li, div.splitcontentleft ul li, div.wiki ol li, div.wiki
 div.wiki ul.toc li { padding: 0; }
 ol li ol li { list-style-type: lower-alpha; }
 ol li ol li ol li { list-style-type: lower-roman; }
+
+/* Schedule Plugin */
+table.schedule_entry_cal ul {padding-left: 5px; padding-right: 5px;}
+table.schedule_entry_cal li { list-style-type: none; }
+table.schedule_entry_cal li div { padding: 4px; }


### PR DESCRIPTION
Hi, 

I am using your basecamp theme together with the schedule plugin to coordinate my staff along the various projects. I thought the default HTML list style in the schedule table was a bit ugly, so my patch is just about to turn that off and correct some paddding.

Would be great to see it in the original theme.

Thx,
McGo
